### PR TITLE
Adaptation of the game list to the user's local time using JavaScript

### DIFF
--- a/template/game_list.tpl
+++ b/template/game_list.tpl
@@ -70,3 +70,18 @@
         </tr>
     {/foreach}
 </table>
+<script>
+    /*
+    This script is calculating the references by local browser's time.
+    */
+
+    for (let dateField of document.getElementsByClassName('date_field')) {
+        if (dateField.textContent == null) continue;
+        //u00a0 represents &nbsp;
+        const inputArray = dateField.textContent.replace(/\u00a0-\u00a0/, '.').replace(' ', '').split(/[.:]/);
+        //Date month is indexed -> 0 represents january. Converting offset to milliseconds.
+        const date = new Date(new Date(20 + inputArray[2], inputArray[1] - 1, inputArray[0], inputArray[3], inputArray[4]).getTime() - new Date().getTimezoneOffset() * 60000);
+        //Adding leading zero to month, day, hour and minute but only keeping the last two numbers
+        dateField.textContent = ("0" + date.getDate()).slice(-2) + '.' + ("0" + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear().toString().slice(2) + "\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2) + ':' + ("0" + date.getMinutes()).slice(-2);
+    }
+</script>

--- a/template/game_list_row.tpl
+++ b/template/game_list_row.tpl
@@ -28,7 +28,7 @@
                     <a href="{url part="game" method="details" q="game[id]={$game.id}"}">{$game.scenario_name|escape}</a>
                 {/if}
             </td>
-            <td align="right">
+            <td align="right" class="date_field">
                 {*{if $smarty.now|date_format:"%d.%m.%Y" == $game.date_created|date_format:"%d.%m.%Y"}
                     {$game.date_created|date_format:"%H:%M:%S"}
                 {else}


### PR DESCRIPTION
With this change the user will be able to see the game information in his local time. This assumes that the game dates are always returned in UTC by the server. The change consists of JavaScript which parses the date column in the table and set an offset.