### PR TITLE
Displaying dates in game-detail view in local time

### DIFF
--- a/js/date-offset.js
+++ b/js/date-offset.js
@@ -1,0 +1,23 @@
+/*
+This script is calculating the references by local browser's time.
+*/
+
+document.addEventListener("DOMContentLoaded", function(event) {
+    for (let dateField of document.getElementsByClassName('date_field')) {
+        if (dateField.textContent == null) continue;
+        //u00a0 represents &nbsp;
+        const inputArray = dateField.textContent.replace(/\u00a0-\u00a0/, '.').replace(' ', '').split(/[.:]/);
+        //Date month is indexed -> 0 represents january. Converting offset to milliseconds.
+        if (inputArray.length === 5) {
+            //Format for e.g. game list "12.08.21 - 17:24"
+            const date = new Date(Date.UTC(20 + inputArray[2], inputArray[1] - 1, inputArray[0], inputArray[3], inputArray[4]));
+            //Adding leading zero to month, day, hour and minute but only keeping the last two numbers
+            dateField.textContent = ("0" + date.getDate()).slice(-2) + '.' + ("0" + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear().toString().slice(2) + "\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2) + ':' + ("0" + date.getMinutes()).slice(-2);
+        } else if (inputArray.length === 6) {
+            //Format for e.g. league detail view "12.08.21 - 17:24:26"
+            const date = new Date(Date.UTC(20 + inputArray[2], inputArray[1] - 1, inputArray[0], inputArray[3], inputArray[4], inputArray[5]));
+            //Adding leading zero to month, day, hour, minute and second but only keeping the last two numbers
+            dateField.textContent = ("0" + date.getDate()).slice(-2) + '.' + ("0" + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear().toString().slice(2) + "\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2) + ':' + ("0" + date.getMinutes()).slice(-2) + ':' + ("0" + date.getSeconds()).slice(-2);
+        }
+    }
+});

--- a/template/game_details.tpl
+++ b/template/game_details.tpl
@@ -7,7 +7,7 @@
 {else}
     {$game.scenario_name|escape}
 {/if}
-<br><b>{$l->s('date_start')}:</b> {$game.date_created|date_format:"%d.%m.%y - %H:%M:%S"}
+<br><b>{$l->s('date_start')}:</b> <span class="date_field">{$game.date_created|date_format:"%d.%m.%y - %H:%M:%S"}</span>
 <br><b>{$l->s('duration')}:</b> {include file="game_duration.tpl"}
 {if $game.type == 'settle'}
   <br><b>{$l->s('duration_equivalent')}:</b>
@@ -19,7 +19,7 @@
                 {$hours}:{$minutes}:{$seconds}
 {/if}
 
-<br><b>{$l->s('date_last_update')}:</b> {$game.date_last_update|date_format:"%d.%m.%y - %H:%M:%S"}
+<br><b>{$l->s('date_last_update')}:</b> <span class="date_field">{$game.date_last_update|date_format:"%d.%m.%y - %H:%M:%S"}</span>
 <br><b>{$l->s('status')}:</b>
                 {if $game.status == 'running'}
                     <img src="{$base_path}images/icons/status_running_16.gif" title="{$l->s('running')}">

--- a/template/game_list.tpl
+++ b/template/game_list.tpl
@@ -70,18 +70,3 @@
         </tr>
     {/foreach}
 </table>
-<script>
-    /*
-    This script is calculating the references by local browser's time.
-    */
-
-    for (let dateField of document.getElementsByClassName('date_field')) {
-        if (dateField.textContent == null) continue;
-        //u00a0 represents &nbsp;
-        const inputArray = dateField.textContent.replace(/\u00a0-\u00a0/, '.').replace(' ', '').split(/[.:]/);
-        //Date month is indexed -> 0 represents january. Converting offset to milliseconds.
-        const date = new Date(new Date(20 + inputArray[2], inputArray[1] - 1, inputArray[0], inputArray[3], inputArray[4]).getTime() - new Date().getTimezoneOffset() * 60000);
-        //Adding leading zero to month, day, hour and minute but only keeping the last two numbers
-        dateField.textContent = ("0" + date.getDate()).slice(-2) + '.' + ("0" + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear().toString().slice(2) + "\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2) + ':' + ("0" + date.getMinutes()).slice(-2);
-    }
-</script>

--- a/template/main.tpl
+++ b/template/main.tpl
@@ -5,6 +5,7 @@
     <title>Clonkspot {$l->s('league')}</title>
     <link rel="stylesheet" type="text/css" href="/css/clonkspot.css">
     <link rel="stylesheet" type="text/css" href="{$base_path}league.css">
+    <script src="js/date-offset.js"></script>
 </head>
 <body>
 
@@ -25,13 +26,13 @@
 {elseif 'league'==$part}
     {if 'list'==$method}
         {include file='league_list.tpl'}
-    {else if 'ranking'==$method || 'clan_ranking'==$method}
+    {elseif 'ranking'==$method || 'clan_ranking'==$method}
         {include file='league_ranking.tpl'}
     {/if}
 {elseif 'game'==$part}
     {if 'list'==$method}
         {include file='game_list.tpl'}
-    {else if 'details'==$method}
+    {elseif 'details'==$method}
         {include file='game_details.tpl'}
     {/if}
 {elseif 'clan'==$part}

--- a/template/main.tpl
+++ b/template/main.tpl
@@ -5,7 +5,7 @@
     <title>Clonkspot {$l->s('league')}</title>
     <link rel="stylesheet" type="text/css" href="/css/clonkspot.css">
     <link rel="stylesheet" type="text/css" href="{$base_path}league.css">
-    <script src="js/date-offset.js"></script>
+    <script src="{$base_path}js/date-offset.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Follow-up of #11:

- The date fields of the game-details view are also adjusted by the script now
- The script is no more inline, it's outsourced to /js/date-offset.js
- Using internal offset calculator of the Date-Class (`new Date(Date.UTC(y, m, d ...))`)