### PR TITLE
Use data-attribute to parse timestamps in standardized format

### DIFF
--- a/js/date-offset.js
+++ b/js/date-offset.js
@@ -4,23 +4,25 @@ This script is calculating the references by local browser's time.
 
 document.addEventListener("DOMContentLoaded", function (event) {
 
-    for (let dateField of document.querySelectorAll('[data-iso-timestamp]')) {
-        const date = new Date(dateField.getAttribute('data-iso-timestamp'));
-        //Date must be valid, 'data-timestamp-meticulousness' must exist
-        if (isNaN(date.getMonth()) || !dateField.hasAttribute('data-timestamp-meticulousness')) continue;
-        const meticulousness = ["YEARS", "MONTHS", "DAYS", "HOURS", "MINUTES", "SECONDS"].indexOf(dateField.getAttribute('data-timestamp-meticulousness'));
+    for (let dateField of document.getElementsByClassName('date_field')) {
+        // 'data-iso-timestamp' and 'data-timestamp-precision' must exist
+        if (dateField.dataset.isoTimestamp === undefined || dateField.dataset.timestampPrecision === undefined) continue;
+        const date = new Date(dateField.dataset.isoTimestamp);
+        //Date must be valid
+        if (isNaN(date.getMonth())) continue;
+        const precision = ["YEARS", "MONTHS", "DAYS", "HOURS", "MINUTES", "SECONDS"].indexOf(dateField.dataset.timestampPrecision);
 
-        if (meticulousness >= 0) {
+        if (precision >= 0) {
             //Adding leading zero to month, day, hour and minute but only keeping the last two numbers
             let outputDate = date.getFullYear().toString().slice(2);
-            if (meticulousness >= 2) outputDate = (("0" + (date.getMonth() + 1)).slice(-2) + '.').concat(outputDate);
-            if (meticulousness >= 1) outputDate = (("0" + date.getDate()).slice(-2) + '.').concat(outputDate);
+            if (precision >= 2) outputDate = (("0" + (date.getMonth() + 1)).slice(-2) + '.').concat(outputDate);
+            if (precision >= 1) outputDate = (("0" + date.getDate()).slice(-2) + '.').concat(outputDate);
             //Date month is indexed -> 0 represents january.
             //u00a0 represents &nbsp;
-            if (meticulousness >= 3) outputDate = outputDate.concat("\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2));
-            if (meticulousness === 3) outputDate = outputDate.concat(":00");
-            if (meticulousness >= 4) outputDate = outputDate.concat(':' + ("0" + date.getMinutes()).slice(-2));
-            if (meticulousness >= 5) outputDate = outputDate.concat(':' + ("0" + date.getSeconds()).slice(-2));
+            if (precision >= 3) outputDate = outputDate.concat("\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2));
+            if (precision === 3) outputDate = outputDate.concat(":00");
+            if (precision >= 4) outputDate = outputDate.concat(':' + ("0" + date.getMinutes()).slice(-2));
+            if (precision >= 5) outputDate = outputDate.concat(':' + ("0" + date.getSeconds()).slice(-2));
 
             dateField.textContent = outputDate;
         }

--- a/js/date-offset.js
+++ b/js/date-offset.js
@@ -19,10 +19,10 @@ document.addEventListener("DOMContentLoaded", function (event) {
             if (precision >= 1) outputDate = (("0" + date.getDate()).slice(-2) + '.').concat(outputDate);
             //Date month is indexed -> 0 represents january.
             //u00a0 represents &nbsp;
-            if (precision >= 3) outputDate = outputDate.concat("\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2));
-            if (precision === 3) outputDate = outputDate.concat(":00");
-            if (precision >= 4) outputDate = outputDate.concat(':' + ("0" + date.getMinutes()).slice(-2));
-            if (precision >= 5) outputDate = outputDate.concat(':' + ("0" + date.getSeconds()).slice(-2));
+            if (precision >= 3) outputDate += "\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2);
+            if (precision === 3) outputDate += ":00";
+            if (precision >= 4) outputDate += ':' + ("0" + date.getMinutes()).slice(-2);
+            if (precision >= 5) outputDate += ':' + ("0" + date.getSeconds()).slice(-2);
 
             dateField.textContent = outputDate;
         }

--- a/js/date-offset.js
+++ b/js/date-offset.js
@@ -2,22 +2,27 @@
 This script is calculating the references by local browser's time.
 */
 
-document.addEventListener("DOMContentLoaded", function(event) {
-    for (let dateField of document.getElementsByClassName('date_field')) {
-        if (dateField.textContent == null) continue;
-        //u00a0 represents &nbsp;
-        const inputArray = dateField.textContent.replace(/\u00a0-\u00a0/, '.').replace(' ', '').split(/[-.:]/);
-        //Date month is indexed -> 0 represents january. Converting offset to milliseconds.
-        if (inputArray.length === 5) {
-            //Format for e.g. game list "12.08.21 - 17:24"
-            const date = new Date(Date.UTC(20 + inputArray[2], inputArray[1] - 1, inputArray[0], inputArray[3], inputArray[4]));
+document.addEventListener("DOMContentLoaded", function (event) {
+
+    for (let dateField of document.querySelectorAll('[data-iso-timestamp]')) {
+        const date = new Date(dateField.getAttribute('data-iso-timestamp'));
+        //Date must be valid, 'data-timestamp-meticulousness' must exist
+        if (isNaN(date.getMonth()) || !dateField.hasAttribute('data-timestamp-meticulousness')) continue;
+        const meticulousness = ["YEARS", "MONTHS", "DAYS", "HOURS", "MINUTES", "SECONDS"].indexOf(dateField.getAttribute('data-timestamp-meticulousness'));
+
+        if (meticulousness >= 0) {
             //Adding leading zero to month, day, hour and minute but only keeping the last two numbers
-            dateField.textContent = ("0" + date.getDate()).slice(-2) + '.' + ("0" + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear().toString().slice(2) + "\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2) + ':' + ("0" + date.getMinutes()).slice(-2);
-        } else if (inputArray.length === 6) {
-            //Format for e.g. league detail view "12.08.21 - 17:24:26"
-            const date = new Date(Date.UTC(20 + inputArray[2], inputArray[1] - 1, inputArray[0], inputArray[3], inputArray[4], inputArray[5]));
-            //Adding leading zero to month, day, hour, minute and second but only keeping the last two numbers
-            dateField.textContent = ("0" + date.getDate()).slice(-2) + '.' + ("0" + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear().toString().slice(2) + "\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2) + ':' + ("0" + date.getMinutes()).slice(-2) + ':' + ("0" + date.getSeconds()).slice(-2);
+            let outputDate = date.getFullYear().toString().slice(2);
+            if (meticulousness >= 2) outputDate = (("0" + (date.getMonth() + 1)).slice(-2) + '.').concat(outputDate);
+            if (meticulousness >= 1) outputDate = (("0" + date.getDate()).slice(-2) + '.').concat(outputDate);
+            //Date month is indexed -> 0 represents january.
+            //u00a0 represents &nbsp;
+            if (meticulousness >= 3) outputDate = outputDate.concat("\u00a0-\u00a0" + ("0" + date.getHours()).slice(-2));
+            if (meticulousness === 3) outputDate = outputDate.concat(":00");
+            if (meticulousness >= 4) outputDate = outputDate.concat(':' + ("0" + date.getMinutes()).slice(-2));
+            if (meticulousness >= 5) outputDate = outputDate.concat(':' + ("0" + date.getSeconds()).slice(-2));
+
+            dateField.textContent = outputDate;
         }
     }
 });

--- a/template/game_details.tpl
+++ b/template/game_details.tpl
@@ -7,7 +7,7 @@
 {else}
     {$game.scenario_name|escape}
 {/if}
-<br><b>{$l->s('date_start')}:</b> <span class="date_field">{$game.date_created|date_format:"%d.%m.%y - %H:%M:%S"}</span>
+<br><b>{$l->s('date_start')}:</b> <span data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-meticulousness="SECONDS">{$game.date_created|date_format:"%d.%m.%y - %H:%M:%S"}</span>
 <br><b>{$l->s('duration')}:</b> {include file="game_duration.tpl"}
 {if $game.type == 'settle'}
   <br><b>{$l->s('duration_equivalent')}:</b>
@@ -19,7 +19,7 @@
                 {$hours}:{$minutes}:{$seconds}
 {/if}
 
-<br><b>{$l->s('date_last_update')}:</b> <span class="date_field">{$game.date_last_update|date_format:"%d.%m.%y - %H:%M:%S"}</span>
+<br><b>{$l->s('date_last_update')}:</b> <span data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-meticulousness="SECONDS">{$game.date_last_update|date_format:"%d.%m.%y - %H:%M:%S"}</span>
 <br><b>{$l->s('status')}:</b>
                 {if $game.status == 'running'}
                     <img src="{$base_path}images/icons/status_running_16.gif" title="{$l->s('running')}">

--- a/template/game_details.tpl
+++ b/template/game_details.tpl
@@ -7,7 +7,7 @@
 {else}
     {$game.scenario_name|escape}
 {/if}
-<br><b>{$l->s('date_start')}:</b> <span class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-precision="SECONDS">{$game.date_created|date_format:"%d.%m.%y - %H:%M:%S"}</span>
+<br><b>{$l->s('date_start')}:</b> <span class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%S%z"}" data-timestamp-precision="SECONDS">{$game.date_created|date_format:"%d.%m.%y - %H:%M:%S"}</span>
 <br><b>{$l->s('duration')}:</b> {include file="game_duration.tpl"}
 {if $game.type == 'settle'}
   <br><b>{$l->s('duration_equivalent')}:</b>
@@ -19,7 +19,7 @@
                 {$hours}:{$minutes}:{$seconds}
 {/if}
 
-<br><b>{$l->s('date_last_update')}:</b> <span class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-precision="SECONDS">{$game.date_last_update|date_format:"%d.%m.%y - %H:%M:%S"}</span>
+<br><b>{$l->s('date_last_update')}:</b> <span class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%S%z"}" data-timestamp-precision="SECONDS">{$game.date_last_update|date_format:"%d.%m.%y - %H:%M:%S"}</span>
 <br><b>{$l->s('status')}:</b>
                 {if $game.status == 'running'}
                     <img src="{$base_path}images/icons/status_running_16.gif" title="{$l->s('running')}">

--- a/template/game_details.tpl
+++ b/template/game_details.tpl
@@ -7,7 +7,7 @@
 {else}
     {$game.scenario_name|escape}
 {/if}
-<br><b>{$l->s('date_start')}:</b> <span data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-meticulousness="SECONDS">{$game.date_created|date_format:"%d.%m.%y - %H:%M:%S"}</span>
+<br><b>{$l->s('date_start')}:</b> <span class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-precision="SECONDS">{$game.date_created|date_format:"%d.%m.%y - %H:%M:%S"}</span>
 <br><b>{$l->s('duration')}:</b> {include file="game_duration.tpl"}
 {if $game.type == 'settle'}
   <br><b>{$l->s('duration_equivalent')}:</b>
@@ -19,7 +19,7 @@
                 {$hours}:{$minutes}:{$seconds}
 {/if}
 
-<br><b>{$l->s('date_last_update')}:</b> <span data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-meticulousness="SECONDS">{$game.date_last_update|date_format:"%d.%m.%y - %H:%M:%S"}</span>
+<br><b>{$l->s('date_last_update')}:</b> <span class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-precision="SECONDS">{$game.date_last_update|date_format:"%d.%m.%y - %H:%M:%S"}</span>
 <br><b>{$l->s('status')}:</b>
                 {if $game.status == 'running'}
                     <img src="{$base_path}images/icons/status_running_16.gif" title="{$l->s('running')}">

--- a/template/game_list_row.tpl
+++ b/template/game_list_row.tpl
@@ -28,7 +28,7 @@
                     <a href="{url part="game" method="details" q="game[id]={$game.id}"}">{$game.scenario_name|escape}</a>
                 {/if}
             </td>
-            <td align="right" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-meticulousness="MINUTES">
+            <td align="right" class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-precision="MINUTES">
                 {*{if $smarty.now|date_format:"%d.%m.%Y" == $game.date_created|date_format:"%d.%m.%Y"}
                     {$game.date_created|date_format:"%H:%M:%S"}
                 {else}

--- a/template/game_list_row.tpl
+++ b/template/game_list_row.tpl
@@ -28,7 +28,7 @@
                     <a href="{url part="game" method="details" q="game[id]={$game.id}"}">{$game.scenario_name|escape}</a>
                 {/if}
             </td>
-            <td align="right" class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-precision="MINUTES">
+            <td align="right" class="date_field" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%S%z"}" data-timestamp-precision="MINUTES">
                 {*{if $smarty.now|date_format:"%d.%m.%Y" == $game.date_created|date_format:"%d.%m.%Y"}
                     {$game.date_created|date_format:"%H:%M:%S"}
                 {else}

--- a/template/game_list_row.tpl
+++ b/template/game_list_row.tpl
@@ -28,7 +28,7 @@
                     <a href="{url part="game" method="details" q="game[id]={$game.id}"}">{$game.scenario_name|escape}</a>
                 {/if}
             </td>
-            <td align="right" class="date_field">
+            <td align="right" data-iso-timestamp="{$game.date_created|date_format:"%Y-%m-%dT%H:%M:%SZ"}" data-timestamp-meticulousness="MINUTES">
                 {*{if $smarty.now|date_format:"%d.%m.%Y" == $game.date_created|date_format:"%d.%m.%Y"}
                     {$game.date_created|date_format:"%H:%M:%S"}
                 {else}


### PR DESCRIPTION
Added data-attribute with ISO-8601 compliant timestamp to html-elements which contains dates to avoid parsing errors and extended date-offset-script for 5 output-formats.